### PR TITLE
allow user to define package version

### DIFF
--- a/Go/build_go.sh
+++ b/Go/build_go.sh
@@ -11,7 +11,7 @@
 set -e -o pipefail
 
 PACKAGE_NAME="go"
-PACKAGE_VERSION="1.11.4"
+[ -z "$PACKAGE_VERSION" ] && PACKAGE_VERSION="1.11.4"
 LOG_FILE="logs/${PACKAGE_NAME}-${PACKAGE_VERSION}-$(date +"%F-%T").log"
 OVERRIDE=false
 


### PR DESCRIPTION
export PACKAGE_VERSION before running build_go.sh to allow version other than default hardcoded in script.  Required for beats build script as newer go versions break beats.