### PR TITLE
Added support for rhel-8.* to OpenResty build script

### DIFF
--- a/OpenResty/1.17.8.2/build_openresty.sh
+++ b/OpenResty/1.17.8.2/build_openresty.sh
@@ -216,7 +216,7 @@ case "$DISTRO" in
     sudo ln -s make /usr/bin/gmake
     configureAndInstall |& tee -a "$LOG_FILE"
     ;;
-"rhel-7.6" | "rhel-7.7" | "rhel-8.1" | "rhel-8.2")
+"rhel-7.6" | "rhel-7.7" | "rhel-8."?)
     printf -- "Installing %s %s for %s \n" "$PACKAGE_NAME" "$PACKAGE_VERSION" "$DISTRO" |& tee -a "$LOG_FILE"
     printf -- "Installing dependencies... it may take some time.\n"
     sudo yum install -y curl tar wget make gcc gcc-c++ unix2dos cpan perl postgresql-devel patch pcre-devel readline-devel openssl openssl-devel glibc-common |& tee -a "$LOG_FILE"


### PR DESCRIPTION
With this change, the openresty build should not exit for future releases of 8.x ..
we have validated the modified script on both rhel 8.2 and rhel 8.3,

`RHEL-8.2:`
```
[root@edacac8b097b /]# cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="8.2 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.2"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.2 (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8.2:GA"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.2
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.2"
[root@edacac8b097b /]#
[root@edacac8b097b /]# resty -e 'print("hello, world")'
hello, world
[root@edacac8b097b /]#
```

`RHEL-8.3`
```
[root@ec9eb517abfb /]# uname -m
s390x
[root@ec9eb517abfb /]# cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="8.3 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.3"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.3 (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8.3:GA"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.3
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.3"
[root@ec9eb517abfb /]# resty -e 'print("hello, world")'
hello, world
[root@ec9eb517abfb /]#
```

Please review: @aborkar-ibm 